### PR TITLE
Added a decrypt_pin method for ISO 9564 PIN blocks

### DIFF
--- a/lib/dukpt/decrypter.rb
+++ b/lib/dukpt/decrypter.rb
@@ -20,6 +20,21 @@ module DUKPT
       decrypt(cryptogram, ksn)
     end
 
+    def decrypt_pin(cryptogram, ksn, pan)
+      pan &&= pan.downcase.chomp('f')
+      decrypted_block = decrypt_pin_block(cryptogram, ksn).unpack("H*").first
+      block_format = decrypted_block[0]
+      if block_format == "0"
+        coded_pan = "0000"+pan[-13..-2]
+        coded_pin = (decrypted_block.to_i(16) ^ coded_pan.to_i(16)).to_s(16).rjust(16, '0')
+        pin_count = coded_pin[1].to_i
+        coded_pin[2,pin_count]
+      elsif block_format == "1"
+        pin_count = decrypted_block[1]
+        coded_pin[2,pin_count]
+      end
+    end
+
     def decrypt_data_block(cryptogram, ksn)
       ipek = derive_IPEK(bdk, ksn)
       dek = derive_DEK(ipek, ksn)

--- a/lib/dukpt/version.rb
+++ b/lib/dukpt/version.rb
@@ -1,3 +1,3 @@
 module DUKPT
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/test/decrypter_test.rb
+++ b/test/decrypter_test.rb
@@ -12,10 +12,9 @@ class DUKPT::DecrypterTest < Test::Unit::TestCase
     
     decrypter = DUKPT::Decrypter.new(bdk, "cbc")
     assert_equal plaintext, decrypter.decrypt(ciphertext, ksn)
-    assert_equal plaintext, decrypter.decrypt_pin_block(ciphertext, ksn)
   end
 
-    def test_decrypt_data_block
+  def test_decrypt_data_block
     bdk = "0123456789ABCDEFFEDCBA9876543210"
     ksn = "FFFF01040DA058E00001"
     ciphertext = "85A8A7F9390FD19EABC40B5D624190287D729923D9EDAFE9F24773388A9A1BEF"
@@ -24,5 +23,27 @@ class DUKPT::DecrypterTest < Test::Unit::TestCase
     decrypter = DUKPT::Decrypter.new(bdk, "cbc")
     assert_equal plaintext, decrypter.decrypt_data_block(ciphertext, ksn)
   end
+
+  def test_decrypt_pin
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "F8765432108D12400014"
+    ciphertext = "129C4FC2537BB63E"
+    pan = "5413330089601109"
+    plaintext_pin = "4315"
+    
+    decrypter = DUKPT::Decrypter.new(bdk)
+    assert_equal plaintext_pin, decrypter.decrypt_pin(ciphertext, ksn, pan)
+  end
   
+  def test_decrypt_pin_with_padded_pan
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "F8765432108D12400011"
+    ciphertext = "8C3169A2ABC1632F"
+    pan = "6799998900000060919F"
+    plaintext_pin = "4315"
+    
+    decrypter = DUKPT::Decrypter.new(bdk)
+    assert_equal plaintext_pin, decrypter.decrypt_pin(ciphertext, ksn, pan)
+  end
+
 end


### PR DESCRIPTION
This was helpful for debugging so I thought I'd share :)

review please @davidseal 

cc @Shopify/pos-checkout 