### PR TITLE
Add PIN encryption

### DIFF
--- a/lib/dukpt.rb
+++ b/lib/dukpt.rb
@@ -1,3 +1,4 @@
 require 'dukpt/encryption'
 require 'dukpt/decrypter'
+require 'dukpt/encrypter'
 require "dukpt/version"

--- a/lib/dukpt/encrypter.rb
+++ b/lib/dukpt/encrypter.rb
@@ -1,0 +1,31 @@
+module DUKPT
+  class Encrypter
+    include Encryption
+
+    attr_reader :bdk
+
+    def initialize(bdk, mode=nil)
+      @bdk = bdk
+      self.cipher_mode = mode.nil? ? 'cbc' : mode
+    end
+
+    def encrypt(message, ksn)
+      ipek = derive_IPEK(bdk, ksn)
+      pek = derive_PEK(ipek, ksn)
+      cryptogram = triple_des_encrypt(pek, message)
+      [cryptogram].pack('H*')
+    end
+
+    def encrypt_pin_block(pin_block, ksn)
+      encrypt(pin_block, ksn)
+    end
+
+    def encrypt_pin(pin, pan, ksn)
+      pan &&= pan.downcase.chomp('f')
+      pin_field = "0#{pin.length}#{pin}".ljust(16, 'f')
+      pan_field = "0000#{pan[-13..-2]}"
+      pin_block = (pin_field.to_i(16) ^ pan_field.to_i(16)).to_s(16).rjust(16, '0')
+      encrypt_pin_block(pin_block, ksn).unpack('H*').first
+    end
+  end
+end

--- a/test/encrypter_test.rb
+++ b/test/encrypter_test.rb
@@ -1,0 +1,27 @@
+require 'bundler/setup'
+require 'test/unit'
+require 'dukpt'
+
+class DUKPT::EncrypterTest < Test::Unit::TestCase
+  def test_encrypt_pin
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "F8765432108D12400014"
+    plaintext_pin = "4315"
+    ciphertext = "129C4FC2537BB63E"
+    pan = "5413330089601109"
+
+    encrypter = DUKPT::Encrypter.new(bdk)
+    assert_equal ciphertext, encrypter.encrypt_pin(plaintext_pin, pan, ksn).upcase
+  end
+
+  def test_encrypt_pin_with_padded_pan
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "F8765432108D12400014"
+    plaintext_pin = "4315"
+    ciphertext = "129C4FC2537BB63E"
+    pan = "5413330089601109F"
+
+    encrypter = DUKPT::Encrypter.new(bdk)
+    assert_equal ciphertext, encrypter.encrypt_pin(plaintext_pin, pan, ksn).upcase
+  end
+end


### PR DESCRIPTION
To match the `decrypt_pin` method in the existing `Decrypter` class, this PR adds an `encrypt_pin` helper in the new `Encrypter` class. As the tests should show, `encrypt_pin` is simply the inverse of `decrypt_pin` and currently assumes that we're using block format 0.