### PR TITLE
Fix 'warning: constant OpenSSL::Cipher::Cipher is deprecated'

### DIFF
--- a/lib/dukpt/encryption.rb
+++ b/lib/dukpt/encryption.rb
@@ -139,7 +139,7 @@ module DUKPT
     end
     
     def openssl_encrypt(cipher_type, key, message, is_encrypt)
-    	cipher = OpenSSL::Cipher::Cipher::new(cipher_type)
+      cipher = OpenSSL::Cipher.new(cipher_type)
     	is_encrypt ? cipher.encrypt : cipher.decrypt
     	cipher.padding = 0
     	cipher.key = [key].pack('H*')


### PR DESCRIPTION
This warning is shown on more recent Ruby versions (2.5)