### PR TITLE
Encryption support and cleanup from static analysis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'test-unit'

--- a/lib/dukpt.rb
+++ b/lib/dukpt.rb
@@ -1,3 +1,4 @@
 require 'dukpt/encryption'
 require 'dukpt/decrypter'
+require 'dukpt/encrypter'
 require "dukpt/version"

--- a/lib/dukpt/decrypter.rb
+++ b/lib/dukpt/decrypter.rb
@@ -10,14 +10,14 @@ module DUKPT
     end
 
     def decrypt(cryptogram, ksn)
+      decrypt_pin_block(cryptogram, ksn)
+    end
+
+    def decrypt_pin_block(cryptogram, ksn)
       ipek = derive_IPEK(bdk, ksn)
       pek = derive_PEK(ipek, ksn)
       decrypted_cryptogram = triple_des_decrypt(pek, cryptogram)
       [decrypted_cryptogram].pack('H*')
-    end
-
-    def decrypt_pin_block(cryptogram, ksn)
-      decrypt(cryptogram, ksn)
     end
 
     def decrypt_pin(cryptogram, ksn, pan)

--- a/lib/dukpt/encrypter.rb
+++ b/lib/dukpt/encrypter.rb
@@ -1,0 +1,28 @@
+module DUKPT
+  class Encrypter
+    include Encryption
+    
+    attr_reader :bdk
+
+    def initialize(bdk, mode=nil)
+      @bdk = bdk
+      self.cipher_mode = mode.nil? ? 'cbc' : mode
+    end
+
+    def encrypt(plaintext, ksn)
+      encrypt_pin_block(plaintext, ksn)
+    end
+
+    def encrypt_pin_block(plaintext, ksn)
+      ipek = derive_IPEK(bdk, ksn)
+      pek = derive_PEK(ipek, ksn)
+      triple_des_encrypt(pek, plaintext.unpack("H*").first).upcase
+    end
+
+    def encrypt_data_block(plaintext, ksn)
+      ipek = derive_IPEK(bdk, ksn)
+      dek = derive_DEK(ipek, ksn)
+      triple_des_encrypt(dek, plaintext.unpack("H*").first).upcase
+    end
+  end
+end

--- a/lib/dukpt/encryption.rb
+++ b/lib/dukpt/encryption.rb
@@ -94,7 +94,7 @@ module DUKPT
     	left_half_of_ipek = triple_des_encrypt(bdk, hex_string_from_val(ksn_cleared_count, 8)) 
     	xor_base_derivation_key = bdk.to_i(16) ^ KEY_MASK
     	right_half_of_ipek = triple_des_encrypt(hex_string_from_val(xor_base_derivation_key, 8), hex_string_from_val(ksn_cleared_count, 8))
-    	ipek_derived = left_half_of_ipek + right_half_of_ipek
+    	left_half_of_ipek + right_half_of_ipek
     end
     
     def aes_decrypt(key, message)
@@ -116,11 +116,11 @@ module DUKPT
     private
 
     def cipher_type_des
-      @cipher_type_des || "des-cbc"
+      @cipher_type_des ||= "des-cbc"
     end
 
     def cipher_type_tdes
-      @cipher_type_tdes || "des-ede-cbc"
+      @cipher_type_tdes ||= "des-ede-cbc"
     end
     
     def hex_string_from_val val, bytes

--- a/lib/dukpt/version.rb
+++ b/lib/dukpt/version.rb
@@ -1,3 +1,3 @@
 module DUKPT
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/encrypter_test.rb
+++ b/test/encrypter_test.rb
@@ -1,0 +1,26 @@
+require 'bundler/setup'
+require 'test/unit'
+require 'dukpt'
+
+class DUKPT::EncrypterTest < Test::Unit::TestCase  
+  
+  def test_decrypt_track_data
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "FFFF9876543210E00008"
+    ciphertext = "C25C1D1197D31CAA87285D59A892047426D9182EC11353C051ADD6D0F072A6CB3436560B3071FC1FD11D9F7E74886742D9BEE0CFD1EA1064C213BB55278B2F12"
+    plaintext = "%B5452300551227189^HOGAN/PAUL      ^08043210000000725000000?\x00\x00\x00\x00"
+    
+    encrypter = DUKPT::Encrypter.new(bdk, "cbc")
+    assert_equal ciphertext, encrypter.encrypt(plaintext, ksn)
+  end
+
+  def test_decrypt_data_block
+    bdk = "0123456789ABCDEFFEDCBA9876543210"
+    ksn = "FFFF01040DA058E00001"
+    ciphertext = "85A8A7F9390FD19EABC40B5D624190287D729923D9EDAFE9F24773388A9A1BEF"
+    plaintext = ["5A08476173900101001057114761739001010010D15122011143878089000000"].pack("H*")
+    
+    encrypter = DUKPT::Encrypter.new(bdk, "cbc")
+    assert_equal ciphertext, encrypter.encrypt_data_block(plaintext, ksn)
+  end
+end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -72,7 +72,7 @@ class DUKPT::EncryptionTest < Test::Unit::TestCase
     assert_equal 'C3DF489FDF11534BF03DE97C27DC4CD0', pek.upcase
   end
 
-def test_derive_pek_counter_EFF800
+  def test_derive_pek_counter_EFF800
     ksn = "FFFF9876543210EFF800"
     pek = derive_PEK('6ac292faa1315b4d858ab3a3d7d5933a', ksn)
     assert_equal 'F9CDFEBF4F5B1D61B3EC12454527E189', pek.upcase


### PR DESCRIPTION
This patch adds an encrypter class to counter the existing decrypter class. It also includes some patches to clean warnings spawned during the test run.

Encrypting PINs was not included because I don't want to have an opinion on which block format to default to just yet.

Padding to the block size was not included because I don't want to have an opinion on which padding character to default to (0x00 or 0xFF) and the decrypter doesn't remove padding anyways.